### PR TITLE
Make prefect_utils production-ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,15 @@ python:
   - 3.8
   - 3.7
   - 3.6
-
+env:
+  - TOXENV=python
+  - TOXENV=quality
+cache:
+  - pip
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install:
+  - pip install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
-script: tox
-
-# Assuming you have installed the travis-ci CLI tool, after you
-# create the Github repo and add it to Travis, run the
-# following command to finish PyPI deployment setup:
-# $ travis encrypt --add deploy.password
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: edx
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: doctoryes/prefect_utils
-    python: 3.8
+script:
+  - tox

--- a/prefect_utils/bigquery.py
+++ b/prefect_utils/bigquery.py
@@ -25,10 +25,11 @@ def cleanup_gcs_files(gcp_credentials: dict, url: str, project: str):
     prefix = parsed_url.path.lstrip("/")
     blobs = bucket.list_blobs(prefix=prefix)
     bucket.delete_blobs(blobs)
+    return blobs
 
 
 @task
-def extract_ga_table(project, gcp_credentials, dataset, date, output_root):
+def extract_ga_table(project: str, gcp_credentials: dict, dataset: str, date: str, output_root: str):
     """
     Runs a BigQuery extraction job, extracting the google analytics' `ga_sessions` table for a
     given date to a location in GCS in gzipped compressed JSON format.

--- a/prefect_utils/bigquery.py
+++ b/prefect_utils/bigquery.py
@@ -3,10 +3,11 @@ Utility methods and tasks for working with BigQuery/Google Cloud Storage from a 
 """
 
 import os
+from urllib.parse import urlparse
+
 from google.cloud import bigquery
 from prefect import task
 from prefect.utilities.gcp import get_bigquery_client, get_storage_client
-from urllib.parse import urlparse
 
 
 @task

--- a/prefect_utils/cli.py
+++ b/prefect_utils/cli.py
@@ -2,6 +2,7 @@
 Console script for prefect_utils.
 """
 import sys
+
 import click
 
 

--- a/prefect_utils/common.py
+++ b/prefect_utils/common.py
@@ -1,8 +1,9 @@
 """
-Utility methods and tasks for working with dates and times from a Prefect flow.
+Utility methods and tasks for use from a Prefect flow.
 """
 
 import datetime
+import itertools
 from prefect import task
 
 
@@ -19,3 +20,22 @@ def generate_dates(start_date: str, end_date: str):
         parsed_start_date = parsed_start_date + datetime.timedelta(days=1)
 
     return [date.strftime("%Y%m%d") for date in dates]
+
+
+@task
+def get_unzipped_cartesian_product(input_lists: list):
+    """
+    Generate an unzipped cartesian product of the given list of lists, useful for
+    generating task parameters for mapping.
+
+    For example, get_unzipped_cartesian_product([[1, 2, 3], ["a", "b", "c"]]) would return:
+
+    [
+      [1, 1, 1, 2, 2, 3, 3, 3],
+      ["a", "b", "c", "a", "b", "c", "a", "b", "c"]
+    ]
+
+    Args:
+      input_lists (list): A list of two or more lists.
+    """
+    return list(zip(*itertools.product(*input_lists)))

--- a/prefect_utils/common.py
+++ b/prefect_utils/common.py
@@ -4,6 +4,7 @@ Utility methods and tasks for use from a Prefect flow.
 
 import datetime
 import itertools
+
 from prefect import task
 
 

--- a/prefect_utils/prefect_utils.py
+++ b/prefect_utils/prefect_utils.py
@@ -1,3 +1,0 @@
-"""
-Main module.
-"""

--- a/prefect_utils/snowflake.py
+++ b/prefect_utils/snowflake.py
@@ -1,11 +1,11 @@
 """
 Utility methods and tasks for working with Snowflake from a Prefect flow.
 """
+import backoff
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from prefect import task
-from snowflake.connector import ProgrammingError
 
 import snowflake.connector
 
@@ -72,7 +72,10 @@ def qualified_stage_name(database, schema, table) -> str:
 
 
 @task
-def load_json_objects_to_snowflake(
+@backoff.on_exception(backoff.expo,
+                      snowflake.connector.ProgrammingError,
+                      max_tries=3)
+def load_ga_data_to_snowflake(
     sf_credentials: dict,
     sf_database: str,
     sf_schema: str,
@@ -80,6 +83,7 @@ def load_json_objects_to_snowflake(
     sf_role: str,
     sf_warehouse: str,
     sf_storage_integration: str,
+    bq_dataset: str,
     gcs_url: str,
     date: str,
     pattern: str = ".*",
@@ -87,7 +91,6 @@ def load_json_objects_to_snowflake(
 ):
     """
     Loads JSON objects from GCS to Snowflake.
-
     Args:
       sf_credentials (dict):
         Snowflake public key credentials in the format required by create_snowflake_connection.
@@ -98,6 +101,7 @@ def load_json_objects_to_snowflake(
       sf_warehouse (str): Name of the Snowflake warehouse to be used for loading.
       sf_storage_integration (str):
         The name of the pre-configured storage integration created for this flow.
+      bq_dataset (str): BQ Dataset to which this load belongs to. This gets set as `ga_view_id' in the dest. table.
       gcs_url (str): Full URL to the GCS path containing the files to load.
       pattern (str, optional): Path pattern/regex to match GCS object to copy.
       date (str): Date of `ga_sessions` being loaded.
@@ -111,14 +115,17 @@ def load_json_objects_to_snowflake(
     try:
         query = """
         SELECT 1 FROM {table}
-        WHERE src:date={date}
+        WHERE session:date='{date}'
+            AND ga_view_id='{ga_view_id}'
         """.format(
-            table=qualified_table_name(sf_database, sf_schema, sf_table), date=date,
+            table=qualified_table_name(sf_database, sf_schema, sf_table),
+            date=date,
+            ga_view_id=bq_dataset,
         )
         cursor = sf_connection.cursor()
         cursor.execute(query)
         row = cursor.fetchone()
-    except ProgrammingError as e:
+    except snowflake.connector.ProgrammingError as e:
         if "does not exist" in e.msg:
             # If so then the query failed because the table doesn't exist.
             row = None
@@ -131,7 +138,10 @@ def load_json_objects_to_snowflake(
     try:
         query = """
         CREATE TABLE IF NOT EXISTS {table} (
-            src VARIANT
+            id number autoincrement start 1 increment 1,
+            load_time timestamp_ltz default current_timestamp(),
+            ga_view_id string,
+            session VARIANT
         );
         """.format(
             table=qualified_table_name(sf_database, sf_schema, sf_table)
@@ -141,9 +151,12 @@ def load_json_objects_to_snowflake(
         if overwrite:
             query = """
             DELETE FROM {table}
-            WHERE src:date={date}
+            WHERE session:date='{date}'
+                AND ga_view_id='{ga_view_id}'
             """.format(
-                table=qualified_table_name(sf_database, sf_schema, sf_table), date=date,
+                table=qualified_table_name(sf_database, sf_schema, sf_table),
+                date=date,
+                ga_view_id=bq_dataset,
             )
             sf_connection.cursor().execute(query)
 
@@ -160,12 +173,18 @@ def load_json_objects_to_snowflake(
         sf_connection.cursor().execute(query)
 
         query = """
-        COPY INTO {table}
-        FROM @{stage_name}
+        COPY INTO {table} (ga_view_id, session)
+            FROM (
+                SELECT
+                    '{ga_view_id}',
+                    t.$1
+                FROM @{stage_name} t
+            )
         PATTERN='{pattern}'
         FORCE={force}
         """.format(
             table=qualified_table_name(sf_database, sf_schema, sf_table),
+            ga_view_id=bq_dataset,
             stage_name=qualified_stage_name(sf_database, sf_schema, sf_table),
             pattern=pattern,
             force=str(overwrite),

--- a/prefect_utils/snowflake.py
+++ b/prefect_utils/snowflake.py
@@ -2,12 +2,10 @@
 Utility methods and tasks for working with Snowflake from a Prefect flow.
 """
 import backoff
-
+import snowflake.connector
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from prefect import task
-
-import snowflake.connector
 
 
 def create_snowflake_connection(

--- a/prefect_utils/vault_secrets.py
+++ b/prefect_utils/vault_secrets.py
@@ -27,8 +27,8 @@ secret in Prefect flows:
         )
         load_data_into_snowflake(sf_credentials)
 """
-from prefect.tasks.secrets import SecretBase
 import hvac
+from prefect.tasks.secrets import SecretBase
 
 # This is a standardized k8s path to always find the service account JWT token.
 SERVICE_ACCOUNT_JWT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-azure-storage-blob==2.1.0  # 12.x seems to be breaking the snowflake connector package.
+backoff==1.10.0
 boto3<1.10.0
 botocore<1.13.0
 hvac

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,47 +5,54 @@
 #    make upgrade
 #
 asn1crypto==1.3.0         # via oscrypto, snowflake-connector-python
-azure-common==1.1.25      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
-azure-storage-blob==2.1.0  # via -r requirements/base.in, snowflake-connector-python
-azure-storage-common==2.1.0  # via azure-storage-blob
+azure-common==1.1.25      # via snowflake-connector-python
+azure-core==1.5.0         # via azure-storage-blob
+azure-storage-blob==12.3.1  # via snowflake-connector-python
+backoff==1.10.0           # via -r requirements/base.in
 boto3==1.9.253            # via -r requirements/base.in, prefect, snowflake-connector-python
 botocore==1.12.253        # via -r requirements/base.in, boto3, s3transfer
 cachetools==4.1.0         # via google-auth
-certifi==2020.4.5.1       # via requests, snowflake-connector-python
+certifi==2020.4.5.1       # via msrest, requests, snowflake-connector-python
 cffi==1.13.2              # via cryptography, snowflake-connector-python
 chardet==3.0.4            # via requests
 click==7.1.2              # via distributed, prefect
 cloudpickle==1.4.1        # via dask, distributed, prefect
-croniter==0.3.31          # via prefect
-cryptography==2.9.2       # via azure-storage-common, pyopenssl, snowflake-connector-python
-dask[bag]==2.16.0         # via distributed, prefect
-distributed==2.16.0       # via prefect
-docker==4.2.0             # via prefect
+contextvars==2.4          # via distributed
+croniter==0.3.32          # via prefect
+cryptography==2.9.2       # via azure-storage-blob, pyopenssl, snowflake-connector-python
+dask[bag]==2.17.2         # via distributed, prefect
+distributed==2.17.0       # via prefect
+docker==4.2.1             # via prefect
 docutils==0.15.2          # via botocore
-fsspec==0.7.3             # via dask
+fsspec==0.7.4             # via dask
 google-api-core==1.17.0   # via google-cloud-bigquery, google-cloud-core
-google-auth==1.14.3       # via google-api-core, google-cloud-bigquery, google-cloud-storage
+google-auth==1.16.0       # via google-api-core, google-cloud-bigquery, google-cloud-storage
 google-cloud-bigquery==1.24.0  # via prefect
 google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-storage
 google-cloud-storage==1.28.1  # via prefect
-google-resumable-media==0.5.0  # via google-cloud-bigquery, google-cloud-storage
+google-resumable-media==0.5.1  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.51.0  # via google-api-core
 graphviz==0.14            # via prefect
 heapdict==1.0.1           # via zict
-hvac==0.10.1              # via -r requirements/base.in
+hvac==0.10.3              # via -r requirements/base.in
 idna==2.9                 # via requests, snowflake-connector-python
 ijson==2.6.1              # via snowflake-connector-python
+immutables==0.14          # via contextvars
+isodate==0.6.0            # via msrest
 jmespath==0.10.0          # via boto3, botocore
 locket==0.2.0             # via partd
 marshmallow-oneofschema==2.0.1  # via prefect
 marshmallow==3.6.0        # via marshmallow-oneofschema, prefect
 msgpack==1.0.0            # via distributed
+msrest==0.6.14            # via azure-storage-blob
 mypy-extensions==0.4.3    # via prefect
+natsort==7.0.1            # via croniter
+oauthlib==3.1.0           # via requests-oauthlib
 oscrypto==1.2.0           # via snowflake-connector-python
 partd==1.1.0              # via dask
 pendulum==2.1.0           # via prefect
-prefect[aws,google,snowflake,viz]==0.11.0  # via -r requirements/base.in
-protobuf==3.11.3          # via google-api-core, google-cloud-bigquery, googleapis-common-protos
+prefect[aws,google,snowflake,viz]==0.11.5  # via -r requirements/base.in
+protobuf==3.12.2          # via google-api-core, google-cloud-bigquery, googleapis-common-protos
 psutil==5.7.0             # via distributed
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
@@ -54,18 +61,19 @@ pycryptodomex==3.9.7      # via snowflake-connector-python
 pyjwt==1.7.1              # via snowflake-connector-python
 pyopenssl==19.1.0         # via snowflake-connector-python
 python-box==4.2.3         # via prefect
-python-dateutil==2.8.1    # via azure-storage-common, botocore, croniter, pendulum, prefect
+python-dateutil==2.8.1    # via botocore, croniter, pendulum, prefect
 python-slugify==4.0.0     # via prefect
 pytz==2020.1              # via google-api-core, prefect, snowflake-connector-python
 pytzdata==2019.3          # via pendulum
-pyyaml==5.3.1             # via distributed, prefect
-requests==2.23.0          # via azure-storage-common, docker, google-api-core, hvac, prefect, snowflake-connector-python
+pyyaml==5.3.1             # via dask, distributed, prefect
+requests-oauthlib==1.3.0  # via msrest
+requests==2.23.0          # via azure-core, docker, google-api-core, hvac, msrest, prefect, requests-oauthlib, snowflake-connector-python
 rsa==4.0                  # via google-auth
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via python-box
 s3transfer==0.2.1         # via boto3
-six==1.14.0               # via cryptography, docker, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, hvac, protobuf, pyopenssl, python-dateutil, websocket-client
-snowflake-connector-python==2.2.6  # via prefect
+six==1.15.0               # via azure-core, cryptography, docker, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, hvac, isodate, protobuf, pyopenssl, python-dateutil, websocket-client
+snowflake-connector-python==2.2.7  # via prefect
 sortedcontainers==2.1.0   # via distributed
 tabulate==0.8.7           # via prefect
 tblib==1.6.0              # via distributed

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asn1crypto==1.3.0         # via oscrypto, snowflake-connector-python
 azure-common==1.1.25      # via snowflake-connector-python
-azure-core==1.5.0         # via azure-storage-blob
+azure-core==1.6.0         # via azure-storage-blob
 azure-storage-blob==12.3.1  # via snowflake-connector-python
 backoff==1.10.0           # via -r requirements/base.in
 boto3==1.9.253            # via -r requirements/base.in, prefect, snowflake-connector-python
@@ -17,7 +17,6 @@ cffi==1.13.2              # via cryptography, snowflake-connector-python
 chardet==3.0.4            # via requests
 click==7.1.2              # via distributed, prefect
 cloudpickle==1.4.1        # via dask, distributed, prefect
-contextvars==2.4          # via distributed
 croniter==0.3.32          # via prefect
 cryptography==2.9.2       # via azure-storage-blob, pyopenssl, snowflake-connector-python
 dask[bag]==2.17.2         # via distributed, prefect
@@ -25,26 +24,25 @@ distributed==2.17.0       # via prefect
 docker==4.2.1             # via prefect
 docutils==0.15.2          # via botocore
 fsspec==0.7.4             # via dask
-google-api-core==1.17.0   # via google-cloud-bigquery, google-cloud-core
-google-auth==1.16.0       # via google-api-core, google-cloud-bigquery, google-cloud-storage
+google-api-core==1.18.0   # via google-cloud-bigquery, google-cloud-core
+google-auth==1.16.1       # via google-api-core, google-cloud-bigquery, google-cloud-storage
 google-cloud-bigquery==1.24.0  # via prefect
 google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-storage
 google-cloud-storage==1.28.1  # via prefect
 google-resumable-media==0.5.1  # via google-cloud-bigquery, google-cloud-storage
-googleapis-common-protos==1.51.0  # via google-api-core
+googleapis-common-protos==1.52.0  # via google-api-core
 graphviz==0.14            # via prefect
 heapdict==1.0.1           # via zict
 hvac==0.10.3              # via -r requirements/base.in
 idna==2.9                 # via requests, snowflake-connector-python
 ijson==2.6.1              # via snowflake-connector-python
-immutables==0.14          # via contextvars
 isodate==0.6.0            # via msrest
 jmespath==0.10.0          # via boto3, botocore
 locket==0.2.0             # via partd
 marshmallow-oneofschema==2.0.1  # via prefect
 marshmallow==3.6.0        # via marshmallow-oneofschema, prefect
 msgpack==1.0.0            # via distributed
-msrest==0.6.14            # via azure-storage-blob
+msrest==0.6.15            # via azure-storage-blob
 mypy-extensions==0.4.3    # via prefect
 natsort==7.0.1            # via croniter
 oauthlib==3.1.0           # via requests-oauthlib

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r requirements/pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.0          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,3 +10,4 @@ pytest==4.6.5
 pytest-runner==5.1
 mock
 pytest-mock
+isort

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ asn1crypto==1.3.0         # via -r requirements/base.txt, oscrypto, snowflake-co
 atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
 azure-common==1.1.25      # via -r requirements/base.txt, snowflake-connector-python
-azure-core==1.5.0         # via -r requirements/base.txt, azure-storage-blob
+azure-core==1.6.0         # via -r requirements/base.txt, azure-storage-blob
 azure-storage-blob==12.3.1  # via -r requirements/base.txt, snowflake-connector-python
 babel==2.8.0              # via sphinx
 backoff==1.10.0           # via -r requirements/base.txt
@@ -24,7 +24,6 @@ cffi==1.13.2              # via -r requirements/base.txt, cryptography, snowflak
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click==7.1.2              # via -r requirements/base.txt, distributed, prefect
 cloudpickle==1.4.1        # via -r requirements/base.txt, dask, distributed, prefect
-contextvars==2.4          # via -r requirements/base.txt, distributed
 croniter==0.3.32          # via -r requirements/base.txt, prefect
 cryptography==2.9.2       # via -r requirements/base.txt, azure-storage-blob, pyopenssl, snowflake-connector-python
 dask[bag]==2.17.2         # via -r requirements/base.txt, distributed, prefect
@@ -34,22 +33,22 @@ docutils==0.15.2          # via -r requirements/base.txt, botocore, readme-rende
 entrypoints==0.3          # via flake8
 flake8==3.7.8             # via -r requirements/test.in
 fsspec==0.7.4             # via -r requirements/base.txt, dask
-google-api-core==1.17.0   # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-core
-google-auth==1.16.0       # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, google-cloud-storage
+google-api-core==1.18.0   # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-core
+google-auth==1.16.1       # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, google-cloud-storage
 google-cloud-bigquery==1.24.0  # via -r requirements/base.txt, prefect
 google-cloud-core==1.3.0  # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-storage
 google-cloud-storage==1.28.1  # via -r requirements/base.txt, prefect
 google-resumable-media==0.5.1  # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-storage
-googleapis-common-protos==1.51.0  # via -r requirements/base.txt, google-api-core
+googleapis-common-protos==1.52.0  # via -r requirements/base.txt, google-api-core
 graphviz==0.14            # via -r requirements/base.txt, prefect
 heapdict==1.0.1           # via -r requirements/base.txt, zict
 hvac==0.10.3              # via -r requirements/base.txt
 idna==2.9                 # via -r requirements/base.txt, requests, snowflake-connector-python
 ijson==2.6.1              # via -r requirements/base.txt, snowflake-connector-python
 imagesize==1.2.0          # via sphinx
-immutables==0.14          # via -r requirements/base.txt, contextvars
 importlib-metadata==1.6.0  # via pluggy, pytest
 isodate==0.6.0            # via -r requirements/base.txt, msrest
+isort==4.3.21             # via -r requirements/test.in
 jinja2==2.11.2            # via sphinx
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 locket==0.2.0             # via -r requirements/base.txt, partd
@@ -60,7 +59,7 @@ mccabe==0.6.1             # via flake8
 mock==4.0.2               # via -r requirements/test.in
 more-itertools==8.3.0     # via pytest
 msgpack==1.0.0            # via -r requirements/base.txt, distributed
-msrest==0.6.14            # via -r requirements/base.txt, azure-storage-blob
+msrest==0.6.15            # via -r requirements/base.txt, azure-storage-blob
 mypy-extensions==0.4.3    # via -r requirements/base.txt, prefect
 natsort==7.0.1            # via -r requirements/base.txt, croniter
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib
@@ -85,7 +84,7 @@ pygments==2.6.1           # via readme-renderer, sphinx
 pyjwt==1.7.1              # via -r requirements/base.txt, snowflake-connector-python
 pyopenssl==19.1.0         # via -r requirements/base.txt, snowflake-connector-python
 pyparsing==2.4.7          # via packaging
-pytest-mock==3.1.0        # via -r requirements/test.in
+pytest-mock==3.1.1        # via -r requirements/test.in
 pytest-runner==5.1        # via -r requirements/test.in
 pytest==4.6.5             # via -r requirements/test.in, pytest-mock
 python-box==4.2.3         # via -r requirements/base.txt, prefect

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,43 +9,47 @@ argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via -r requirements/base.txt, oscrypto, snowflake-connector-python
 atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
-azure-common==1.1.25      # via -r requirements/base.txt, azure-storage-blob, azure-storage-common, snowflake-connector-python
-azure-storage-blob==2.1.0  # via -r requirements/base.txt, snowflake-connector-python
-azure-storage-common==2.1.0  # via -r requirements/base.txt, azure-storage-blob
+azure-common==1.1.25      # via -r requirements/base.txt, snowflake-connector-python
+azure-core==1.5.0         # via -r requirements/base.txt, azure-storage-blob
+azure-storage-blob==12.3.1  # via -r requirements/base.txt, snowflake-connector-python
 babel==2.8.0              # via sphinx
+backoff==1.10.0           # via -r requirements/base.txt
 bleach==3.1.5             # via readme-renderer
 boto3==1.9.253            # via -r requirements/base.txt, prefect, snowflake-connector-python
 botocore==1.12.253        # via -r requirements/base.txt, boto3, s3transfer
 bump2version==0.5.11      # via -r requirements/test.in
 cachetools==4.1.0         # via -r requirements/base.txt, google-auth
-certifi==2020.4.5.1       # via -r requirements/base.txt, requests, snowflake-connector-python
+certifi==2020.4.5.1       # via -r requirements/base.txt, msrest, requests, snowflake-connector-python
 cffi==1.13.2              # via -r requirements/base.txt, cryptography, snowflake-connector-python
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click==7.1.2              # via -r requirements/base.txt, distributed, prefect
 cloudpickle==1.4.1        # via -r requirements/base.txt, dask, distributed, prefect
-croniter==0.3.31          # via -r requirements/base.txt, prefect
-cryptography==2.9.2       # via -r requirements/base.txt, azure-storage-common, pyopenssl, snowflake-connector-python
-dask[bag]==2.16.0         # via -r requirements/base.txt, distributed, prefect
-distributed==2.16.0       # via -r requirements/base.txt, prefect
-docker==4.2.0             # via -r requirements/base.txt, prefect
+contextvars==2.4          # via -r requirements/base.txt, distributed
+croniter==0.3.32          # via -r requirements/base.txt, prefect
+cryptography==2.9.2       # via -r requirements/base.txt, azure-storage-blob, pyopenssl, snowflake-connector-python
+dask[bag]==2.17.2         # via -r requirements/base.txt, distributed, prefect
+distributed==2.17.0       # via -r requirements/base.txt, prefect
+docker==4.2.1             # via -r requirements/base.txt, prefect
 docutils==0.15.2          # via -r requirements/base.txt, botocore, readme-renderer, sphinx
 entrypoints==0.3          # via flake8
 flake8==3.7.8             # via -r requirements/test.in
-fsspec==0.7.3             # via -r requirements/base.txt, dask
+fsspec==0.7.4             # via -r requirements/base.txt, dask
 google-api-core==1.17.0   # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-core
-google-auth==1.14.3       # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, google-cloud-storage
+google-auth==1.16.0       # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, google-cloud-storage
 google-cloud-bigquery==1.24.0  # via -r requirements/base.txt, prefect
 google-cloud-core==1.3.0  # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-storage
 google-cloud-storage==1.28.1  # via -r requirements/base.txt, prefect
-google-resumable-media==0.5.0  # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-storage
+google-resumable-media==0.5.1  # via -r requirements/base.txt, google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.51.0  # via -r requirements/base.txt, google-api-core
 graphviz==0.14            # via -r requirements/base.txt, prefect
 heapdict==1.0.1           # via -r requirements/base.txt, zict
-hvac==0.10.1              # via -r requirements/base.txt
+hvac==0.10.3              # via -r requirements/base.txt
 idna==2.9                 # via -r requirements/base.txt, requests, snowflake-connector-python
 ijson==2.6.1              # via -r requirements/base.txt, snowflake-connector-python
 imagesize==1.2.0          # via sphinx
+immutables==0.14          # via -r requirements/base.txt, contextvars
 importlib-metadata==1.6.0  # via pluggy, pytest
+isodate==0.6.0            # via -r requirements/base.txt, msrest
 jinja2==2.11.2            # via sphinx
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 locket==0.2.0             # via -r requirements/base.txt, partd
@@ -54,18 +58,21 @@ marshmallow-oneofschema==2.0.1  # via -r requirements/base.txt, prefect
 marshmallow==3.6.0        # via -r requirements/base.txt, marshmallow-oneofschema, prefect
 mccabe==0.6.1             # via flake8
 mock==4.0.2               # via -r requirements/test.in
-more-itertools==8.2.0     # via pytest
+more-itertools==8.3.0     # via pytest
 msgpack==1.0.0            # via -r requirements/base.txt, distributed
+msrest==0.6.14            # via -r requirements/base.txt, azure-storage-blob
 mypy-extensions==0.4.3    # via -r requirements/base.txt, prefect
+natsort==7.0.1            # via -r requirements/base.txt, croniter
+oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib
 oscrypto==1.2.0           # via -r requirements/base.txt, snowflake-connector-python
-packaging==20.3           # via bleach, pytest, sphinx
+packaging==20.4           # via bleach, pytest, sphinx
 partd==1.1.0              # via -r requirements/base.txt, dask
 pathtools==0.1.2          # via watchdog
 pendulum==2.1.0           # via -r requirements/base.txt, prefect
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest
-prefect[aws,google,snowflake,viz]==0.11.0  # via -r requirements/base.txt
-protobuf==3.11.3          # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, googleapis-common-protos
+prefect[aws,google,snowflake,viz]==0.11.5  # via -r requirements/base.txt
+protobuf==3.12.2          # via -r requirements/base.txt, google-api-core, google-cloud-bigquery, googleapis-common-protos
 psutil==5.7.0             # via -r requirements/base.txt, distributed
 py==1.8.1                 # via pytest
 pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
@@ -82,21 +89,22 @@ pytest-mock==3.1.0        # via -r requirements/test.in
 pytest-runner==5.1        # via -r requirements/test.in
 pytest==4.6.5             # via -r requirements/test.in, pytest-mock
 python-box==4.2.3         # via -r requirements/base.txt, prefect
-python-dateutil==2.8.1    # via -r requirements/base.txt, azure-storage-common, botocore, croniter, pendulum, prefect
+python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, croniter, pendulum, prefect
 python-slugify==4.0.0     # via -r requirements/base.txt, prefect
 pytz==2020.1              # via -r requirements/base.txt, babel, google-api-core, prefect, snowflake-connector-python
 pytzdata==2019.3          # via -r requirements/base.txt, pendulum
-pyyaml==5.3.1             # via -r requirements/base.txt, distributed, prefect, watchdog
+pyyaml==5.3.1             # via -r requirements/base.txt, dask, distributed, prefect, watchdog
 readme-renderer==26.0     # via twine
+requests-oauthlib==1.3.0  # via -r requirements/base.txt, msrest
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via -r requirements/base.txt, azure-storage-common, docker, google-api-core, hvac, prefect, requests-toolbelt, snowflake-connector-python, sphinx, twine
+requests==2.23.0          # via -r requirements/base.txt, azure-core, docker, google-api-core, hvac, msrest, prefect, requests-oauthlib, requests-toolbelt, snowflake-connector-python, sphinx, twine
 rsa==4.0                  # via -r requirements/base.txt, google-auth
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/base.txt, python-box
 s3transfer==0.2.1         # via -r requirements/base.txt, boto3
-six==1.14.0               # via -r requirements/base.txt, bleach, cryptography, docker, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, hvac, packaging, protobuf, pyopenssl, pytest, python-dateutil, readme-renderer, sphinx, websocket-client
+six==1.15.0               # via -r requirements/base.txt, azure-core, bleach, cryptography, docker, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, hvac, isodate, packaging, protobuf, pyopenssl, pytest, python-dateutil, readme-renderer, sphinx, websocket-client
 snowballstemmer==2.0.0    # via sphinx
-snowflake-connector-python==2.2.6  # via -r requirements/base.txt, prefect
+snowflake-connector-python==2.2.7  # via -r requirements/base.txt, prefect
 sortedcontainers==2.1.0   # via -r requirements/base.txt, distributed
 sphinx==1.8.5             # via -r requirements/test.in
 sphinxcontrib-websupport==1.2.2  # via sphinx
@@ -106,11 +114,11 @@ text-unidecode==1.3       # via -r requirements/base.txt, python-slugify
 toml==0.10.1              # via -r requirements/base.txt, prefect, python-box
 toolz==0.10.0             # via -r requirements/base.txt, dask, distributed, partd
 tornado==6.0.4            # via -r requirements/base.txt, distributed
-tqdm==4.46.0              # via twine
+tqdm==4.46.1              # via twine
 twine==1.14.0             # via -r requirements/test.in
 urllib3==1.25.9           # via -r requirements/base.txt, botocore, prefect, requests, snowflake-connector-python
 watchdog==0.9.0           # via -r requirements/test.in
-wcwidth==0.1.9            # via pytest
+wcwidth==0.2.3            # via pytest
 webencodings==0.5.1       # via bleach
 websocket-client==0.57.0  # via -r requirements/base.txt, docker
 wheel==0.33.6             # via -r requirements/test.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,8 +12,7 @@ coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
@@ -25,4 +24,4 @@ tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.15.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
 virtualenv==20.0.21       # via tox
-zipp==3.1.0               # via importlib-metadata, importlib-resources
+zipp==3.1.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,21 +7,22 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
+codecov==2.1.4            # via -r requirements/travis.in
 coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
-packaging==20.3           # via tox
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
-six==1.14.0               # via packaging, tox, virtualenv
+six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox-battery==0.5.2        # via -r requirements/travis.in
-tox==3.15.0               # via -r requirements/travis.in, tox-battery
+tox-battery==0.6.1        # via -r requirements/travis.in
+tox==3.15.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.20       # via tox
-zipp==3.1.0               # via importlib-metadata
+virtualenv==20.0.21       # via tox
+zipp==3.1.0               # via importlib-metadata, importlib-resources

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Unit test package for prefect_utils."""

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -4,8 +4,9 @@
 Tests for BigQuery utils in the `prefect_utils` package.
 """
 
-from pytest_mock import mocker  # noqa: F401
 from prefect.core import Flow
+from pytest_mock import mocker  # noqa: F401
+
 from prefect_utils import bigquery
 
 

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""
+Tests for BigQuery utils in the `prefect_utils` package.
+"""
+
+from pytest_mock import mocker  # noqa: F401
+from prefect.core import Flow
+from prefect_utils import bigquery
+
+
+def test_cleanup_gcs_files(mocker):  # noqa: F811
+    mocker.patch.object(bigquery, 'get_storage_client')
+    with Flow("test") as f:
+        bigquery.cleanup_gcs_files(
+            gcp_credentials={},
+            url='',
+            project='test_project'
+        )
+    state = f.run()
+    assert state.is_successful()
+
+
+def test_extract_ga_table(mocker):  # noqa: F811
+    mocker.patch.object(bigquery, 'get_bigquery_client')
+    with Flow("test") as f:
+        task = bigquery.extract_ga_table(
+            project='test_project',
+            gcp_credentials={},
+            dataset='test_dataset',
+            date='2020-01-01',
+            output_root='test_output_root'
+        )
+    state = f.run()
+    assert state.is_successful()
+    assert state.result[task].result == "test_output_root/test_dataset/2020-01-01"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ Tests for cli utils for the `prefect_utils` package.
 
 import pytest
 from click.testing import CliRunner
+
 from prefect_utils import cli
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+"""
+Tests for BigQuery utils in the `prefect_utils` package.
+"""
+
+from prefect.core import Flow
+from prefect_utils import common
+
+
+def test_generate_dates():
+    with Flow("test") as f:
+        task = common.generate_dates(
+            start_date='2020-01-01',
+            end_date='2020-01-05'
+        )
+    state = f.run()
+    assert state.is_successful()
+    assert state.result[task].result == ['20200101', '20200102', '20200103', '20200104']
+
+
+def test_get_unzipped_cartesian_product():
+    with Flow("test") as f:
+        task = common.get_unzipped_cartesian_product(
+            input_lists=[[1, 2, 3], ["a", "b", "c"]]
+        )
+    state = f.run()
+    assert state.is_successful()
+    assert state.result[task].result == [
+      (1, 1, 1, 2, 2, 2, 3, 3, 3),
+      ("a", "b", "c", "a", "b", "c", "a", "b", "c")
+    ]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,6 +5,7 @@ Tests for BigQuery utils in the `prefect_utils` package.
 """
 
 from prefect.core import Flow
+
 from prefect_utils import common
 
 

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -6,11 +6,12 @@ Tests for Snowflake utils in the `prefect_utils` package.
 
 import mock
 import pytest
-from pytest_mock import mocker  # noqa: F401
 from prefect.core import Flow
 from prefect.utilities.debug import raise_on_exception
-from prefect_utils import snowflake
+from pytest_mock import mocker  # noqa: F401
 from snowflake.connector import ProgrammingError
+
+from prefect_utils import snowflake
 
 
 def test_qualified_table_name():

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -5,8 +5,12 @@ Tests for Snowflake utils in the `prefect_utils` package.
 """
 
 import mock
+import pytest
 from pytest_mock import mocker  # noqa: F401
+from prefect.core import Flow
+from prefect.utilities.debug import raise_on_exception
 from prefect_utils import snowflake
+from snowflake.connector import ProgrammingError
 
 
 def test_qualified_table_name():
@@ -21,8 +25,19 @@ def test_qualified_stage_name():
     )
 
 
-def test_create_snowflake_connection(mocker):  # noqa: F811
+@pytest.fixture
+def mock_sf_connection(mocker):  # noqa: F811
     # Mock the Snowflake connection and cursor.
+    mocker.patch.object(snowflake, 'create_snowflake_connection')
+    mock_cursor = mocker.Mock()
+    mock_connection = mocker.Mock()
+    mock_connection.cursor.return_value = mock_cursor
+    snowflake.create_snowflake_connection.return_value = mock_connection
+    return mock_connection
+
+
+def test_create_snowflake_connection(mocker):  # noqa: F811
+    # Mock out the snowflake connection method w/o mocking out the helper method.
     mocker.patch.object(snowflake.snowflake.connector, 'connect')
     mock_cursor = mocker.Mock()
     mock_connection = mocker.Mock()
@@ -51,11 +66,143 @@ def test_create_snowflake_connection(mocker):  # noqa: F811
     )
     mock_cursor.execute.assert_has_calls(
         (
-            mock.call("USE ROLE test_role"),
-            mock.call("ALTER SESSION SET TIMEZONE = 'UTC'"),
+            mocker.call("USE ROLE test_role"),
+            mocker.call("ALTER SESSION SET TIMEZONE = 'UTC'"),
         )
     )
 
 
-def test_load_json_objects_to_snowflake(mocker):  # noqa: F811
-    pass
+def test_load_json_objects_to_snowflake_no_existing_table(mock_sf_connection):
+    # Mock the Snowflake connection, cursor, and fetchone method.
+    mock_cursor = mock_sf_connection.cursor()
+    mock_fetchone = mock.Mock(side_effect=ProgrammingError("does not exist"))
+    mock_cursor.fetchone = mock_fetchone
+
+    with Flow("test") as f:
+        snowflake.load_ga_data_to_snowflake(
+            sf_credentials={},
+            sf_database="test_database",
+            sf_schema="test_schema",
+            sf_table="test_table",
+            sf_role="test_role",
+            sf_warehouse="test_warehouse",
+            sf_storage_integration="test_storage_integration",
+            bq_dataset="test_dataset",
+            gcs_url="gs://test-location",
+            date="2020-01-01",
+        )
+    state = f.run()
+    assert state.is_successful()
+    mock_cursor.execute.assert_has_calls(
+        [
+            mock.call("\n        SELECT 1 FROM test_database.test_schema.test_table\n        WHERE session:date='2020-01-01'\n            AND ga_view_id='test_dataset'\n        "), # noqa
+            mock.call('\n        CREATE TABLE IF NOT EXISTS test_database.test_schema.test_table (\n            id number autoincrement start 1 increment 1,\n            load_time timestamp_ltz default current_timestamp(),\n            ga_view_id string,\n            session VARIANT\n        );\n        '), # noqa
+            mock.call("\n        CREATE OR REPLACE STAGE test_database.test_schema.test_table_stage\n            URL = 'gcs://test-location'\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = (TYPE = JSON);\n        "), # noqa
+            mock.call("\n        COPY INTO test_database.test_schema.test_table (ga_view_id, session)\n            FROM (\n                SELECT\n                    'test_dataset',\n                    t.$1\n                FROM @test_database.test_schema.test_table_stage t\n            )\n        PATTERN='.*'\n        FORCE=False\n        "), # noqa
+        ]
+    )
+
+
+def test_load_json_objects_to_snowflake_error_on_table_exist_check(mock_sf_connection):
+    # Mock the Snowflake connection, cursor, and fetchone method.
+    mock_cursor = mock_sf_connection.cursor()
+    mock_fetchone = mock.Mock(side_effect=ProgrammingError())
+    mock_cursor.fetchone = mock_fetchone
+
+    with Flow("test") as f:
+        snowflake.load_ga_data_to_snowflake(
+            sf_credentials={},
+            sf_database="test_database",
+            sf_schema="test_schema",
+            sf_table="test_table",
+            sf_role="test_role",
+            sf_warehouse="test_warehouse",
+            sf_storage_integration="test_storage_integration",
+            bq_dataset="test_dataset",
+            gcs_url="gs://test-location",
+            date="2020-01-01",
+        )
+    with raise_on_exception():
+        with pytest.raises(ProgrammingError):
+            f.run()
+
+
+def test_load_json_objects_to_snowflake_overwrite(mock_sf_connection):
+    # Mock the Snowflake connection, cursor, and fetchone method.
+    mock_cursor = mock_sf_connection.cursor()
+    mock_fetchone = mock.Mock(return_value=None)
+    mock_cursor.fetchone = mock_fetchone
+
+    with Flow("test") as f:
+        snowflake.load_ga_data_to_snowflake(
+            sf_credentials={},
+            sf_database="test_database",
+            sf_schema="test_schema",
+            sf_table="test_table",
+            sf_role="test_role",
+            sf_warehouse="test_warehouse",
+            sf_storage_integration="test_storage_integration",
+            bq_dataset="test_dataset",
+            gcs_url="gs://test-location",
+            date="2020-01-01",
+            overwrite=True
+        )
+    state = f.run()
+    assert state.is_successful()
+    mock_cursor.execute.assert_has_calls(
+        [
+            mock.call("\n        SELECT 1 FROM test_database.test_schema.test_table\n        WHERE session:date='2020-01-01'\n            AND ga_view_id='test_dataset'\n        "), # noqa
+            mock.call('\n        CREATE TABLE IF NOT EXISTS test_database.test_schema.test_table (\n            id number autoincrement start 1 increment 1,\n            load_time timestamp_ltz default current_timestamp(),\n            ga_view_id string,\n            session VARIANT\n        );\n        '), # noqa
+            mock.call("\n            DELETE FROM test_database.test_schema.test_table\n            WHERE session:date='2020-01-01'\n                AND ga_view_id='test_dataset'\n            "), # noqa
+            mock.call("\n        CREATE OR REPLACE STAGE test_database.test_schema.test_table_stage\n            URL = 'gcs://test-location'\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = (TYPE = JSON);\n        "), # noqa
+            mock.call("\n        COPY INTO test_database.test_schema.test_table (ga_view_id, session)\n            FROM (\n                SELECT\n                    'test_dataset',\n                    t.$1\n                FROM @test_database.test_schema.test_table_stage t\n            )\n        PATTERN='.*'\n        FORCE=True\n        "), # noqa
+        ]
+    )
+
+
+def test_load_json_objects_to_snowflake_table_exists_no_overwrite(mock_sf_connection):  # noqa: F811
+    # Mock the Snowflake connection, cursor, and fetchone method.
+    mock_cursor = mock_sf_connection.cursor()
+    mock_fetchone = mock.Mock()
+    mock_cursor.fetchone = mock_fetchone
+
+    with Flow("test") as f:
+        snowflake.load_ga_data_to_snowflake(
+            sf_credentials={},
+            sf_database="test_database",
+            sf_schema="test_schema",
+            sf_table="test_table",
+            sf_role="test_role",
+            sf_warehouse="test_warehouse",
+            sf_storage_integration="test_storage_integration",
+            bq_dataset="test_dataset",
+            gcs_url="gs://test-location",
+            date="2020-01-01",
+        )
+    state = f.run()
+    assert state.is_successful()
+    mock_cursor.execute.assert_called_once_with("\n        SELECT 1 FROM test_database.test_schema.test_table\n        WHERE session:date='2020-01-01'\n            AND ga_view_id='test_dataset'\n        ") # noqa
+
+
+def test_load_json_objects_to_snowflake_table_general_exception(mock_sf_connection):
+    # Mock the Snowflake connection, cursor, and fetchone method.
+    mock_commit = mock.Mock(side_effect=Exception)
+    mock_sf_connection.commit = mock_commit
+
+    with Flow("test") as f:
+        snowflake.load_ga_data_to_snowflake(
+            sf_credentials={},
+            sf_database="test_database",
+            sf_schema="test_schema",
+            sf_table="test_table",
+            sf_role="test_role",
+            sf_warehouse="test_warehouse",
+            sf_storage_integration="test_storage_integration",
+            bq_dataset="test_dataset",
+            gcs_url="gs://test-location",
+            date="2020-01-01",
+            overwrite=True
+        )
+    with raise_on_exception():
+        with pytest.raises(Exception):
+            f.run()

--- a/tests/test_vault_secrets.py
+++ b/tests/test_vault_secrets.py
@@ -4,8 +4,9 @@
 Tests for Hashicorp Vault secrets utils in the `prefect_utils` package.
 """
 
-from pytest_mock import mocker  # noqa: F401
 from prefect import Flow, task, unmapped
+from pytest_mock import mocker  # noqa: F401
+
 from prefect_utils import vault_secrets
 
 

--- a/tests/test_vault_secrets.py
+++ b/tests/test_vault_secrets.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+"""
+Tests for Hashicorp Vault secrets utils in the `prefect_utils` package.
+"""
+
+from pytest_mock import mocker  # noqa: F401
+from prefect import Flow, task, unmapped
+from prefect_utils import vault_secrets
+
+
+@task
+def get_val(secret):
+    return secret.get("test")
+
+
+def test_read_vault_secret(mocker):  # noqa: F811
+    mocker.patch.object(vault_secrets, 'open')
+    mocker.patch.object(vault_secrets.hvac, 'Client')
+    with Flow("test") as f:
+        secret_val = vault_secrets.VaultKVSecret(
+            path="warehouses/test_platform/test_secret",
+            version=2
+        )
+        get_val(unmapped(secret_val))
+    state = f.run()
+    assert state.is_successful()

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,11 @@
 [tox]
-envlist = py36, py37, py38, flake8
+envlist = py36, py37, py38, quality
 
 [travis]
 python =
     3.8: py38
     3.7: py37
     3.6: py36
-
-[testenv:flake8]
-basepython = python
-deps = flake8
-commands = flake8 prefect_utils tests
 
 [testenv]
 setenv =
@@ -21,3 +16,16 @@ commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}
 
+[testenv:quality]
+basepython =
+    python
+whitelist_externals =
+    rm
+    touch
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    touch tests/__init__.py
+    flake8 prefect_utils tests
+    rm tests/__init__.py
+    isort --check-only --diff --recursive prefect_utils tests

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements/test.txt
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following line:
-;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}


### PR DESCRIPTION
- Increase test coverage to 96%
- Drop Python 3.5 as a supported version due to `dask[bag]` dependency not installing.

With this PR, this module is ready to be tested with the prefect-flows repo. There's a separate PR there for integration:
https://github.com/edx/prefect-flows/pull/9